### PR TITLE
feat: add ASCII layout instruction to vision model prompts

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -185,7 +185,7 @@ async function seeImageViaSDK(
               ],
               tools: {},
               system:
-                "You are a vision assistant. Describe the image accurately and concisely. Answer with text only.",
+                "You are a vision assistant. Describe the image accurately and concisely. Answer with text only. If the image shows a UI, screen, diagram, layout, or any structured visual interface, include an ASCII diagram representing the spatial arrangement of elements, text, and components.",
             },
             signal: controller.signal,
           })
@@ -388,7 +388,7 @@ const SeeImagePlugin: Plugin = async (ctx) => {
       const prompt =
         args.question && args.question.trim().length > 0
           ? args.question
-          : "Describe this image in detail. If it is a screenshot, describe the UI, text content, and layout precisely. This description will be used by another model to answer the user, so be thorough and accurate."
+          : "Describe this image in detail. If it is a screenshot, describe the UI, text content, and layout precisely. This description will be used by another model to answer the user, so be thorough and accurate. If the image shows a UI, screen, diagram, layout, or any structured visual interface, include an ASCII diagram representing the spatial arrangement of elements, text, and components."
 
       let result: { text: string; model: string; provider: string }
 

--- a/index.ts
+++ b/index.ts
@@ -185,7 +185,7 @@ async function seeImageViaSDK(
               ],
               tools: {},
               system:
-                "You are a vision assistant. Describe the image accurately and concisely. Answer with text only. If the image shows a UI, screen, diagram, layout, or any structured visual interface, include an ASCII diagram representing the spatial arrangement of elements, text, and components.",
+                "You are a vision assistant. Describe the image accurately and concisely. Answer with text only.",
             },
             signal: controller.signal,
           })
@@ -371,9 +371,10 @@ const SeeImagePlugin: Plugin = async (ctx) => {
             '- An error or stack trace screenshot: "Quote the exact error message and stack trace, then state the likely cause."',
             '- Reproducing a UI as code: "Describe the layout, components, text, colors, and spacing precisely enough to rebuild this UI in code."',
             '- A technical diagram/architecture: "Explain this diagram: list each component and the relationships and data/flow direction between them."',
+            '- A UI/screen where positions matter (alignment bugs, "where is X", overlapping or misplaced elements): "Describe the layout and include a labeled ASCII diagram of the spatial arrangement of elements."',
             '- A chart/graph/dashboard: "Read this visualization: axes, series, key values, and the main takeaway."',
             '- Comparing against an expected design: "Describe this UI in detail so it can be diffed against an expected layout (note any visible defects or misalignment)."',
-            "Otherwise pass the user's own specific question verbatim.",
+            'Otherwise pass the user\'s own specific question verbatim. If the question concerns a UI/screen and spatial arrangement matters to answering it, append: "Also include a labeled ASCII diagram of the layout."',
           ].join("\n"),
         ),
     },
@@ -388,7 +389,7 @@ const SeeImagePlugin: Plugin = async (ctx) => {
       const prompt =
         args.question && args.question.trim().length > 0
           ? args.question
-          : "Describe this image in detail. If it is a screenshot, describe the UI, text content, and layout precisely. This description will be used by another model to answer the user, so be thorough and accurate. If the image shows a UI, screen, diagram, layout, or any structured visual interface, include an ASCII diagram representing the spatial arrangement of elements, text, and components."
+          : "Describe this image in detail. If it is a screenshot, describe the UI, text content, and layout precisely. This description will be used by another model to answer the user, so be thorough and accurate."
 
       let result: { text: string; model: string; provider: string }
 


### PR DESCRIPTION
Add an instruction to the vision model prompts requesting an ASCII diagram whenever the image contains a UI, screen, diagram, layout, or any structured visual interface.

### Changes

Two prompts were updated:

1. **SDK system prompt** (`seeImageViaSDK`): The system-level instruction now tells the vision model to include an ASCII diagram representing the spatial arrangement of elements, text, and components when applicable.

2. **Default user prompt**: The fallback description prompt (used when no specific `question` is provided) also carries the same ASCII layout instruction.

This ensures ASCII layout generation works in both SDK and direct HTTP vision paths, and respects the existing `question` parameter — when users provide a specific question, the instruction is not appended (custom prompts are used as-is).

### Why

ASCII layouts make the vision model's output significantly more useful for developers working with UI screenshots, diagrams, and game interfaces — a picture may be worth a thousand words, but an ASCII schematic is worth a thousand pixels when the consuming model needs spatial reasoning.
