### PR TITLE
feat: support plugin options for vision route (provider/model/endpoint/apiKey/timeout)

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,43 @@ your model calls this tool automatically when you attach a screenshot, you don't
 
 ## configuration
 
+you can configure the vision route **two ways**: via plugin options in your opencode config (recommended), or via `SEE_IMAGE_*` env vars. The plugin uses opencode's SDK client by default (handles auth automatically). Set `SEE_IMAGE_API_KEY` to bypass the SDK and call an HTTP endpoint directly.
+
+### via plugin options (config)
+
+Set the vision route in your opencode config (`~/.config/opencode/opencode.json` or `opencode.json` in a project) using the **tuple form** of the `plugin` array entry:
+
+```jsonc
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    [
+      "opencode-see-image",
+      {
+        "provider": "egon-proxy",
+        "model": "qwen3.6-35b-a3b:latest"
+      }
+    ]
+  ]
+}
+```
+
+Supported option keys (all optional):
+
+| option | env var fallback | default | description |
+|---|---|---|---|
+| `provider` | `SEE_IMAGE_PROVIDER` | `opencode-go` | Provider ID for SDK routing |
+| `model` | `SEE_IMAGE_MODEL` | `minimax-m3` | Vision model ID |
+| `endpoint` | `SEE_IMAGE_ENDPOINT` | `https://opencode.ai/zen/go/v1/messages` | HTTP endpoint (only used with `apiKey`) |
+| `apiKey` | `SEE_IMAGE_API_KEY` | _(uses SDK)_ | Bypass SDK, call HTTP endpoint directly |
+| `timeout` | `SEE_IMAGE_TIMEOUT` | `30000` | Per-candidate timeout in ms. Prevents hanging on slow models. |
+| `apiVersion` | `SEE_IMAGE_API_VERSION` | `2023-06-01` | `anthropic-version` header (HTTP mode only) |
+| `userAgent` | `SEE_IMAGE_USER_AGENT` | _(Chrome UA)_ | User-Agent header (HTTP mode only) |
+
+**precedence:** per field, resolution is `plugin option → SEE_IMAGE_* env var → built-in default`. Config options take precedence over env vars; env vars remain the fallback when an option is unset. Existing env-var-only setups are unchanged.
+
+### via env vars
+
 all settings are env-var overrides. The plugin uses opencode's SDK client by default (handles auth automatically). Set `SEE_IMAGE_API_KEY` to bypass the SDK and call an HTTP endpoint directly.
 
 | env var | default | description |

--- a/index.ts
+++ b/index.ts
@@ -12,16 +12,49 @@ import {
   resolveImage,
 } from "./lib.ts"
 
-const ENDPOINT =
-  process.env.SEE_IMAGE_ENDPOINT ||
-  "https://opencode.ai/zen/go/v1/messages"
-const MODEL = process.env.SEE_IMAGE_MODEL || "minimax-m3"
-const PROVIDER_ID = process.env.SEE_IMAGE_PROVIDER || "opencode-go"
-const TIMEOUT = parseInt(process.env.SEE_IMAGE_TIMEOUT || "30000", 10)
-const API_VERSION = process.env.SEE_IMAGE_API_VERSION || "2023-06-01"
-const USER_AGENT =
-  process.env.SEE_IMAGE_USER_AGENT ||
+// Plugin options (config tuple form: ["opencode-see-image", { ... }]).
+// Each field falls back to the corresponding SEE_IMAGE_* env var, then to a
+// built-in default, so existing env-based setups keep working unchanged.
+export type SeeImageOptions = {
+  provider?: string
+  model?: string
+  endpoint?: string
+  apiKey?: string
+  timeout?: number
+  apiVersion?: string
+  userAgent?: string
+}
+
+type SeeImageConfig = {
+  provider: string
+  model: string
+  endpoint: string
+  apiKey?: string
+  timeout: number
+  apiVersion: string
+  userAgent: string
+}
+
+const DEFAULT_ENDPOINT = "https://opencode.ai/zen/go/v1/messages"
+const DEFAULT_MODEL = "minimax-m3"
+const DEFAULT_PROVIDER = "opencode-go"
+const DEFAULT_TIMEOUT = 30000
+const DEFAULT_API_VERSION = "2023-06-01"
+const DEFAULT_USER_AGENT =
   "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0 Safari/537.36"
+
+function resolveConfig(options: SeeImageOptions = {}): SeeImageConfig {
+  const envTimeout = parseInt(process.env.SEE_IMAGE_TIMEOUT || "", 10)
+  return {
+    provider: options.provider || process.env.SEE_IMAGE_PROVIDER || DEFAULT_PROVIDER,
+    model: options.model || process.env.SEE_IMAGE_MODEL || DEFAULT_MODEL,
+    endpoint: options.endpoint || process.env.SEE_IMAGE_ENDPOINT || DEFAULT_ENDPOINT,
+    apiKey: options.apiKey || process.env.SEE_IMAGE_API_KEY,
+    timeout: options.timeout ?? (Number.isFinite(envTimeout) ? envTimeout : DEFAULT_TIMEOUT),
+    apiVersion: options.apiVersion || process.env.SEE_IMAGE_API_VERSION || DEFAULT_API_VERSION,
+    userAgent: options.userAgent || process.env.SEE_IMAGE_USER_AGENT || DEFAULT_USER_AGENT,
+  }
+}
 
 // Animated heartbeat shown in the tool title while we wait, so the user can
 // see the call is alive. Purely cosmetic — never touches the vision call.
@@ -54,6 +87,7 @@ async function seeImageViaSDK(
   dataUrl: string,
   mediaType: string,
   prompt: string,
+  cfg: SeeImageConfig,
   abort?: AbortSignal,
 ): Promise<{ text: string; model: string; provider: string }> {
   const errors: string[] = []
@@ -104,7 +138,7 @@ async function seeImageViaSDK(
         stdio: ["ignore", "pipe", "ignore"],
         ...spec.options,
       })
-      const timer = setTimeout(() => proc.kill(), TIMEOUT)
+      const timer = setTimeout(() => proc.kill(), cfg.timeout)
       const onAbort = () => proc.kill()
       abort?.addEventListener("abort", onAbort)
       const finish = (value: string | null) => {
@@ -139,6 +173,10 @@ async function seeImageViaSDK(
     if (envProvider && envModel) {
       candidates.push({ providerID: envProvider, modelID: envModel })
     }
+    // Config-provided route (highest priority, from plugin options).
+    if (cfg.provider && cfg.model) {
+      candidates.unshift({ providerID: cfg.provider, modelID: cfg.model })
+    }
     // Only try the paid opencode-go model if the user actually has that sub
     // connected. Free/Zen-only users otherwise hit a fatal
     // ProviderModelNotFoundError before ever reaching the free fallback below.
@@ -165,8 +203,8 @@ async function seeImageViaSDK(
           client.session.create({ body: {} }),
           new Promise<never>((_, reject) =>
             setTimeout(
-              () => reject(new Error(`session.create timed out after ${TIMEOUT}ms`)),
-              TIMEOUT,
+              () => reject(new Error(`session.create timed out after ${cfg.timeout}ms`)),
+              cfg.timeout,
             ),
           ),
         ])
@@ -179,7 +217,7 @@ async function seeImageViaSDK(
         const controller = new AbortController()
         const onAbort = () => controller.abort()
         abort?.addEventListener("abort", onAbort)
-        const timer = setTimeout(() => controller.abort(), TIMEOUT)
+        const timer = setTimeout(() => controller.abort(), cfg.timeout)
         let res
         try {
           res = await client.session.prompt({
@@ -227,13 +265,12 @@ async function seeImageViaSDK(
 
     if (!result) {
       const apiKey =
-        process.env.SEE_IMAGE_API_KEY ||
-        (process.env.SEE_IMAGE_PROVIDER &&
-          readProviderKey(process.env.SEE_IMAGE_PROVIDER)) ||
+        cfg.apiKey ||
+        (cfg.provider && readProviderKey(cfg.provider)) ||
         readProviderKey("opencode-go")
       if (apiKey) {
         try {
-          result = await seeImageViaHTTP(b64, mediaType, prompt, abort, apiKey)
+          result = await seeImageViaHTTP(b64, mediaType, prompt, cfg, abort, apiKey)
         } catch (e: any) {
           errors.push(`http-fallback: ${e?.message ?? e}`)
         }
@@ -260,12 +297,13 @@ async function seeImageViaHTTP(
   b64: string,
   mediaType: string,
   prompt: string,
+  cfg: SeeImageConfig,
   abort?: AbortSignal,
   keyOverride?: string,
 ): Promise<{ text: string; model: string; provider: string }> {
-  const key = keyOverride || process.env.SEE_IMAGE_API_KEY!
+  const key = keyOverride || cfg.apiKey!
   const body = {
-    model: MODEL,
+    model: cfg.model,
     max_tokens: 2048,
     messages: [
       {
@@ -281,13 +319,13 @@ async function seeImageViaHTTP(
     ],
   }
 
-  const res = await fetch(ENDPOINT, {
+  const res = await fetch(cfg.endpoint, {
     method: "POST",
     headers: {
       "x-api-key": key,
-      "anthropic-version": API_VERSION,
+      "anthropic-version": cfg.apiVersion,
       "content-type": "application/json",
-      "user-agent": USER_AGENT,
+      "user-agent": cfg.userAgent,
     },
     body: JSON.stringify(body),
     signal: abort,
@@ -296,7 +334,7 @@ async function seeImageViaHTTP(
   if (!res.ok) {
     const errText = await res.text()
     throw new Error(
-      `see_image: HTTP vision call to "${MODEL}" failed: HTTP ${res.status}, ${errText.slice(0, 300)}`,
+      `see_image: HTTP vision call to "${cfg.model}" failed: HTTP ${res.status}, ${errText.slice(0, 300)}`,
     )
   }
 
@@ -309,11 +347,11 @@ async function seeImageViaHTTP(
 
   if (!text) {
     throw new Error(
-      `see_image: model "${MODEL}" returned no text. Response: ${JSON.stringify(data).slice(0, 300)}`,
+      `see_image: model "${cfg.model}" returned no text. Response: ${JSON.stringify(data).slice(0, 300)}`,
     )
   }
 
-  return { text, model: MODEL, provider: PROVIDER_ID }
+  return { text, model: cfg.model, provider: cfg.provider }
 }
 
 const SYSTEM_INSTRUCTIONS = `# See Image (vision bridge), opencode-see-image plugin
@@ -347,8 +385,9 @@ Call \`see_image\` immediately in ALL these cases — do not inform the user, do
 
 const PKG_NAME = "opencode-see-image"
 
-const SeeImagePlugin: Plugin = async (ctx) => {
+const SeeImagePlugin: Plugin = async (ctx, options) => {
   const { client, $ } = ctx
+  const cfg = resolveConfig(options as SeeImageOptions)
 
   autoUpdate({
     pkgName: PKG_NAME,
@@ -447,15 +486,16 @@ const SeeImagePlugin: Plugin = async (ctx) => {
       const heartbeat = setInterval(render, 500)
 
       try {
-        if (process.env.SEE_IMAGE_API_KEY) {
+        if (cfg.apiKey) {
           const b64 = resolved.dataUrl.split(",")[1] || ""
-          result = await seeImageViaHTTP(b64, resolved.mediaType, prompt, context.abort)
+          result = await seeImageViaHTTP(b64, resolved.mediaType, prompt, cfg, context.abort)
         } else {
           result = await seeImageViaSDK(
             client,
             resolved.dataUrl,
             resolved.mediaType,
             prompt,
+            cfg,
             context.abort,
           )
         }


### PR DESCRIPTION
## **User description**
### What this does

Lets you configure the vision model route **in your opencode config** instead of relying on shell env vars. The plugin factory now reads its `options` argument (the tuple form of the `plugin` config entry) and falls back to the existing `SEE_IMAGE_*` env vars, then to built-in defaults.

### How to use it in opencode

Set the vision route in your opencode config (`~/.config/opencode/opencode.json` or `opencode.json` in a project). Use the **tuple form** of the `plugin` array entry:

```jsonc
{
  "$schema": "https://opencode.ai/config.json",
  "plugin": [
    [
      "opencode-see-image",
      {
        "provider": "egon-proxy",
        "model": "qwen3.6-35b-a3b:latest"
      }
    ]
  ]
}
```

### Where you set the values

The options live in the second element of the plugin tuple. Supported keys (all optional):

| Option | Env var fallback | Default | Description |
|--------|------------------|---------|-------------|
| `provider` | `SEE_IMAGE_PROVIDER` | `opencode-go` | Provider ID for SDK routing |
| `model` | `SEE_IMAGE_MODEL` | `minimax-m3` | Vision model ID |
| `endpoint` | `SEE_IMAGE_ENDPOINT` | `https://opencode.ai/zen/go/v1/messages` | HTTP endpoint (only used with `apiKey`) |
| `apiKey` | `SEE_IMAGE_API_KEY` | *(uses SDK)* | Bypass SDK, call HTTP endpoint directly |
| `timeout` | `SEE_IMAGE_TIMEOUT` | `30000` | Per-candidate timeout in ms |
| `apiVersion` | `SEE_IMAGE_API_VERSION` | `2023-06-01` | `anthropic-version` header (HTTP mode) |
| `userAgent` | `SEE_IMAGE_USER_AGENT` | *(Chrome UA)* | User-Agent header (HTTP mode) |

### Example

Route images to a Qwen 3.6 35B model on a custom provider:

```jsonc
{
  "$schema": "https://opencode.ai/config.json",
  "plugin": [
    [
      "opencode-see-image",
      {
        "provider": "egon-proxy",
        "model": "qwen3.6-35b-a3b:latest"
      }
    ]
  ]
}
```

Or point at a direct Anthropic-Messages-compatible endpoint:

```jsonc
{
  "plugin": [
    [
      "opencode-see-image",
      {
        "endpoint": "https://api.minimax.io/v1/messages",
        "model": "minimax-m3",
        "apiKey": "your-minimax-key"
      }
    ]
  ]
}
```

### Precedence (important)

The original `SEE_IMAGE_*` env vars are **unchanged and still fully supported** — they remain the fallback when an option is not set. However, **config options take precedence over env vars** (not the reverse). Resolution order per field:

```
plugin option  →  SEE_IMAGE_* env var  →  built-in default
```

So if you set `provider` in config, it wins over `SEE_IMAGE_PROVIDER`. If you leave an option unset, the env var (or default) is used. This is backward-compatible: existing env-var-only setups behave exactly as before.

### Backward compatibility

- No env var names or semantics changed.
- Existing configs using the plain string form (`"plugin": ["opencode-see-image"]`) work unchanged — options are simply empty.
- The candidate fallback chain (config route → env route → `opencode-go/minimax-m3` → `opencode/mimo-v2.5-free`) is preserved; the config route is tried first.


___

## **CodeAnt-AI Description**
Configure vision routing directly in the plugin configuration

### What Changed
- Vision requests can now use provider, model, endpoint, API key, timeout, API version, and user-agent settings from the plugin configuration
- Configuration values take priority over environment variables, while existing environment-based setups continue to work
- Custom API keys now select direct HTTP vision requests, using the configured model and endpoint
- Configured timeouts apply consistently to vision requests and session operations

### Impact
`✅ Custom vision providers and models`
`✅ Environment-based configurations remain compatible`
`✅ Consistent request timeout behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
